### PR TITLE
Implemented lazy loading

### DIFF
--- a/src/TreeComponent/Tree.razor
+++ b/src/TreeComponent/Tree.razor
@@ -14,7 +14,7 @@
 
         <div>
             
-            @if (hasChilds)
+            @if (hasChilds && nodeExpanded)
             {
                 <span class="uic-tree__icon" @onclick="@(() => OnToggleNode(node, !nodeExpanded))">
                     <i class="@(nodeExpanded ? Style.CollapseNodeIconClass : Style.ExpandNodeIconClass)"></i>
@@ -84,6 +84,8 @@
             ExpandedNodes.Add(node);
             ExpandedNodesChanged.InvokeAsync(ExpandedNodes);
         }
+    
+        StateHasChanged();
     }
 
     private void OnSelectNode(TNode node)


### PR DESCRIPTION
Added lazy loading because otherwise while making a tree for the filesystem starting from `C:\` it would try to load every single file and folder in memory (recursively) to build the entire tree beforehand.