### PR TITLE
Parameter for maximum displayed filter options

### DIFF
--- a/src/TagSelectorComponent/TagSelector.razor
+++ b/src/TagSelectorComponent/TagSelector.razor
@@ -23,7 +23,7 @@
     {
         <div class="uic-tag-selector__dropdown @Style.DropdownClass">
 
-            @foreach (var item in _selectableItems)
+            @foreach (var item in _selectableItems.Take(MaxFilterItems))
             {
                 <div class="@Style.DropdownItemClass @(_selectableItems.IndexOf(item) == _selectableIndex ? "uic-tag-selector__item--selected " + Style.DropdownItemHoverClass : "")" @onmousedown="@(() => AddSelectedTag(item, true))">
                     @TagTemplate(item)
@@ -52,6 +52,8 @@
     [Parameter] public EventCallback<TItem> OnTagRemoved { get; set; }
 
     [Parameter] public EventCallback<string> OnCreateTag { get; set; }
+        
+    [Parameter] public int MaxFilterItems { get; set; } = 10;
 
     private bool _selectionOpen;
     private string _filterText;


### PR DESCRIPTION
When used with large lists of selectable tags, the UI can become a bit laggy. This adds a parameter to the TagSelector.razor component to limit the number of filtered items displayed. The default number is 10, but this can be adjusted by setting MaxFilterItems as needed.